### PR TITLE
More efficient parsing

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -23,4 +23,5 @@ dependencies:
       - pyprojroot 
       - scikit-learn
       - hydra-core 
-      - tensorboard 
+      - tensorboard
+      - mmcif

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
       - scikit-learn
       - hydra-core 
       - tensorboard
-      - mmcif
+      - rcsb.utils.io

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -6,15 +6,15 @@ from rcsb.utils.io.MarshalUtil import MarshalUtil
 min_num_residues = 10
 
 
-def get_poly_entities(data_container):
+def get_poly_entities(data_container) -> set:
     entity = data_container.getObj('entity')
-    poly_ent_ids = []
+    poly_ent_ids = set()
     for i in range(0, len(entity.data)):
         d_row = entity.getRowAttributeDict(i)
         ent_id = d_row["id"]
         ent_type = d_row["type"]
         if ent_type == "polymer":
-            poly_ent_ids.append(ent_id)
+            poly_ent_ids.add(ent_id)
     return poly_ent_ids
 
 

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -62,18 +62,16 @@ def get_coords_from_file(cif_file_url):
     :param cif_file_url: a link to a bcif file
     :return:
     """
-
     mU = MarshalUtil()
     data_container_list = mU.doImport(cif_file_url, fmt="bcif")
     data_container = data_container_list[0]
     poly_ent_ids = get_poly_entities(data_container)
     chain_coords, chain_seqs = get_ca_coords(data_container, poly_ent_ids)
-
     return chain_coords, chain_seqs
 
 
 def get_coords_for_pdb_id(pdb_id):
-    url = "https://models.rcsb.org/%s.bcif" % pdb_id
+    url = "https://models.rcsb.org/%s.bcif" % pdb_id.lower()
     chain_coords, chain_seqs = get_coords_from_file(url)
     print("Found %d valid protein chains in %s. Asym_ids are : %s" % (len(chain_coords), pdb_id, ",".join(chain_coords.keys())))
     return chain_coords, chain_seqs

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -71,7 +71,7 @@ def get_coords_for_pdb_id(pdb_id, tmp_dir):
     print("Downloading %s to %s" % (url, filepath_local))
     urllib.request.urlretrieve(url, filepath_local)
     chain_coords = get_coords_from_file(filepath_local)
-    print("Found %d valid protein chains in %s. Asym_ids are : %s" % (len(chain_coords), pdb_id, chain_coords.keys()))
+    print("Found %d valid protein chains in %s. Asym_ids are : %s" % (len(chain_coords), pdb_id, ",".join(chain_coords.keys())))
     os.remove(filepath_local)
     return chain_coords
 

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -20,7 +20,7 @@ def get_poly_entities(data_container) -> set:
     return poly_ent_ids
 
 
-def get_ca_coords(data_container, poly_ent_ids: list):
+def get_ca_coords(data_container, poly_ent_ids: set):
     atom_sites = data_container.getObj('atom_site')
     coords_current_chain = []
     polychains_coords = {}
@@ -54,7 +54,7 @@ def get_ca_coords(data_container, poly_ent_ids: list):
     return polychains_coords, polychains_seqs
 
 
-def get_coords_from_file(cif_file_url):
+def get_coords_from_file(cif_file_url: str):
     """
     Get 2 dictionaries: 1) coordinates, with keys asym_ids of protein polymer entities and values the
     coordinates as a list of 3-size lists; 2) sequences, with keys asym_ids of protein polymer entities and values the
@@ -71,7 +71,7 @@ def get_coords_from_file(cif_file_url):
     return chain_coords, chain_seqs
 
 
-def get_coords_for_pdb_id(pdb_id):
+def get_coords_for_pdb_id(pdb_id: str):
     url = "https://models.rcsb.org/%s.bcif.gz" % pdb_id.lower()
     chain_coords, chain_seqs = get_coords_from_file(url)
     print("Found %d valid protein chains in %s. Asym_ids are : %s" % (len(chain_coords), pdb_id, ",".join(chain_coords.keys())))

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -1,9 +1,8 @@
 from Bio.Data.PDBData import protein_letters_3to1_extended
+from Bio.PDB.Polypeptide import is_aa
 from rcsb.utils.io.MarshalUtil import MarshalUtil
 
 
-aas = ["GLY", "ALA", "VAL", "LEU", "ILE", "PHE", "TYR", "TRP", "PRO", "HIS",
-       "LYS", "ARG", "SER", "THR", "GLU", "GLN", "ASP", "ASN", "CYS", "MET"]
 min_num_residues = 10
 
 
@@ -43,7 +42,7 @@ def get_ca_coords(data_container, poly_ent_ids: list):
         atom_type = d_row["label_atom_id"]
         model_num = d_row["pdbx_PDB_model_num"]
         alt_loc = d_row["label_alt_id"]
-        if atom_type == "CA" and model_num == 1 and aa_type in aas and (alt_loc == "." or alt_loc == "A"):
+        if atom_type == "CA" and model_num == 1 and is_aa(aa_type) and (alt_loc == "." or alt_loc == "A"):
             coords_current_chain.append([d_row["Cartn_x"], d_row["Cartn_y"], d_row["Cartn_z"]])
             current_seq.append(protein_letters_3to1_extended[aa_type])
         asym_id = current_asym_id

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -1,3 +1,5 @@
+import time
+
 from Bio.Data.PDBData import protein_letters_3to1_extended
 from Bio.PDB.Polypeptide import is_aa
 from rcsb.utils.io.MarshalUtil import MarshalUtil
@@ -77,8 +79,10 @@ def get_coords_for_pdb_id(pdb_id):
 
 
 def main():
+    start = time.process_time()
     chain_coords, chain_seqs = get_coords_for_pdb_id("2trx")
-    print(chain_coords.keys())
+    end = time.process_time()
+    print("Done in %f s. Keys: %s" % (end-start, ",".join(chain_coords.keys())))
 
 
 if __name__ == "__main__":

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -72,7 +72,7 @@ def get_coords_from_file(cif_file_url):
 
 
 def get_coords_for_pdb_id(pdb_id):
-    url = "https://models.rcsb.org/%s.bcif" % pdb_id.lower()
+    url = "https://models.rcsb.org/%s.bcif.gz" % pdb_id.lower()
     chain_coords, chain_seqs = get_coords_from_file(url)
     print("Found %d valid protein chains in %s. Asym_ids are : %s" % (len(chain_coords), pdb_id, ",".join(chain_coords.keys())))
     return chain_coords, chain_seqs

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -1,0 +1,99 @@
+import os
+import urllib.request
+from mmcif.io.IoAdapterCore import IoAdapterCore
+
+
+aas = ["GLY", "ALA", "VAL", "LEU", "ILE", "PHE", "TYR", "TRP", "PRO", "HIS",
+       "LYS", "ARG", "SER", "THR", "GLU", "GLN", "ASP", "ASN", "CYS", "MET"]
+
+
+def get_poly_entities(data_container):
+    entity = data_container.getObj('entity')
+    poly_ent_ids = []
+    for i in range(0, len(entity.data)):
+        d_row = entity.getRowAttributeDict(i)
+        ent_id = d_row["id"]
+        ent_type = d_row["type"]
+        if ent_type == "polymer":
+            poly_ent_ids.append(ent_id)
+    return poly_ent_ids
+
+
+def get_entity_to_asym_map(data_container):
+    atom_sites = data_container.getObj('atom_site')
+    entity_to_asym = {}
+    for i in range(0, len(atom_sites.data)):
+        d_row = atom_sites.getRowAttributeDict(i)
+        ent_id = d_row["label_entity_id"]
+        current_asym_id = d_row["label_asym_id"]
+        if ent_id not in entity_to_asym:
+            entity_to_asym[ent_id] = {current_asym_id}
+        else:
+            entity_to_asym[ent_id].add(current_asym_id)
+    return entity_to_asym
+
+
+def get_ca_coords(data_container, asym_id: str):
+
+    atom_sites = data_container.getObj('atom_site')
+
+    coords = []
+    for i in range(0, len(atom_sites.data)):
+        d_row = atom_sites.getRowAttributeDict(i)
+        current_asym_id = d_row["label_asym_id"]
+        if current_asym_id != asym_id:
+            continue
+        aa_type = d_row["label_comp_id"]
+        atom_type = d_row["label_atom_id"]
+        model_num = int(d_row["pdbx_PDB_model_num"])
+        if aa_type not in aas:
+            continue
+        if atom_type != "CA":
+            continue
+        if model_num != 1:
+            continue
+        coords.append([d_row["Cartn_x"], d_row["Cartn_y"], d_row["Cartn_z"]])
+    return coords
+
+
+def get_coords_from_file(local_cif_file):
+    """
+    Get a dictionary with keys asym_ids of protein polymer entities and values the coordinates as a list of 3-size lists.
+    If no protein polymer entities found the dictionary will be empty.
+    :param local_cif_file:
+    :return:
+    """
+    io = IoAdapterCore()
+    list_data_container = io.readFile(local_cif_file)
+    data_container = list_data_container[0]
+
+    poly_ent_ids = get_poly_entities(data_container)
+    entity_to_asym = get_entity_to_asym_map(data_container)
+
+    chain_coords = {}
+    for ent_id in poly_ent_ids:
+        for asym_id in entity_to_asym[ent_id]:
+            cas = get_ca_coords(data_container, asym_id)
+            if len(cas) != 0:
+                chain_coords[asym_id] = cas
+    return chain_coords
+
+
+def get_coords_for_pdb_id(pdb_id, tmp_dir):
+    url = "https://files.rcsb.org/download/%s.cif.gz" % pdb_id
+    filepath_local = os.path.join(tmp_dir, "%s.cif.gz" % pdb_id)
+    print("Downloading %s to %s" % (url, filepath_local))
+    urllib.request.urlretrieve(url, filepath_local)
+    chain_coords = get_coords_from_file(filepath_local)
+    os.remove(filepath_local)
+    return chain_coords
+
+
+def main():
+
+    chain_coords = get_coords_for_pdb_id("3hbx", "/tmp")
+    print(chain_coords.keys())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -60,7 +60,6 @@ def get_coords_from_file(local_cif_file):
     data_container = list_data_container[0]
 
     poly_ent_ids = get_poly_entities(data_container)
-
     chain_coords = get_ca_coords(data_container, poly_ent_ids)
 
     return chain_coords
@@ -72,6 +71,7 @@ def get_coords_for_pdb_id(pdb_id, tmp_dir):
     print("Downloading %s to %s" % (url, filepath_local))
     urllib.request.urlretrieve(url, filepath_local)
     chain_coords = get_coords_from_file(filepath_local)
+    print("Found %d valid protein chains in %s. Asym_ids are : %s" % (len(chain_coords), pdb_id, chain_coords.keys()))
     os.remove(filepath_local)
     return chain_coords
 

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -5,6 +5,7 @@ from mmcif.io.IoAdapterCore import IoAdapterCore
 
 aas = ["GLY", "ALA", "VAL", "LEU", "ILE", "PHE", "TYR", "TRP", "PRO", "HIS",
        "LYS", "ARG", "SER", "THR", "GLU", "GLN", "ASP", "ASN", "CYS", "MET"]
+min_num_residues = 10
 
 
 def get_poly_entities(data_container):
@@ -31,7 +32,8 @@ def get_ca_coords(data_container, poly_ent_ids: list):
             continue
         current_asym_id = d_row["label_asym_id"]
         if asym_id is not None and current_asym_id != asym_id:
-            if len(coords_current_chain) >= 10:  # we'll keep only chains with at least 10 residues
+            # we'll keep only chains with at least this residues. This should also filter out dna/rna
+            if len(coords_current_chain) >= min_num_residues:
                 polychains_coords[asym_id] = coords_current_chain
             coords_current_chain = []
         aa_type = d_row["label_comp_id"]
@@ -41,7 +43,7 @@ def get_ca_coords(data_container, poly_ent_ids: list):
         if atom_type == "CA" and model_num == "1" and aa_type in aas and (alt_loc == "." or alt_loc == "A"):
             coords_current_chain.append([float(d_row["Cartn_x"]), float(d_row["Cartn_y"]), float(d_row["Cartn_z"])])
         asym_id = current_asym_id
-    if len(coords_current_chain) >= 10 and asym_id not in polychains_coords:
+    if len(coords_current_chain) >= min_num_residues and asym_id not in polychains_coords:
         polychains_coords[asym_id] = coords_current_chain
     return polychains_coords
 

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -19,41 +19,31 @@ def get_poly_entities(data_container):
     return poly_ent_ids
 
 
-def get_entity_to_asym_map(data_container):
+def get_ca_coords(data_container, poly_ent_ids: list):
     atom_sites = data_container.getObj('atom_site')
-    entity_to_asym = {}
+    coords_current_chain = []
+    polychains_coords = {}
+    asym_id = None
     for i in range(0, len(atom_sites.data)):
         d_row = atom_sites.getRowAttributeDict(i)
         ent_id = d_row["label_entity_id"]
-        current_asym_id = d_row["label_asym_id"]
-        if ent_id not in entity_to_asym:
-            entity_to_asym[ent_id] = {current_asym_id}
-        else:
-            entity_to_asym[ent_id].add(current_asym_id)
-    return entity_to_asym
-
-
-def get_ca_coords(data_container, asym_id: str):
-
-    atom_sites = data_container.getObj('atom_site')
-
-    coords = []
-    for i in range(0, len(atom_sites.data)):
-        d_row = atom_sites.getRowAttributeDict(i)
-        current_asym_id = d_row["label_asym_id"]
-        if current_asym_id != asym_id:
+        if ent_id not in poly_ent_ids:
             continue
+        current_asym_id = d_row["label_asym_id"]
+        if asym_id is not None and current_asym_id != asym_id:
+            if len(coords_current_chain) >= 10:  # we'll keep only chains with at least 10 residues
+                polychains_coords[asym_id] = coords_current_chain
+            coords_current_chain = []
         aa_type = d_row["label_comp_id"]
         atom_type = d_row["label_atom_id"]
-        model_num = int(d_row["pdbx_PDB_model_num"])
-        if aa_type not in aas:
-            continue
-        if atom_type != "CA":
-            continue
-        if model_num != 1:
-            continue
-        coords.append([d_row["Cartn_x"], d_row["Cartn_y"], d_row["Cartn_z"]])
-    return coords
+        model_num = d_row["pdbx_PDB_model_num"]
+        alt_loc = d_row["label_alt_id"]
+        if atom_type == "CA" and model_num == "1" and aa_type in aas and (alt_loc == "." or alt_loc == "A"):
+            coords_current_chain.append([float(d_row["Cartn_x"]), float(d_row["Cartn_y"]), float(d_row["Cartn_z"])])
+        asym_id = current_asym_id
+    if len(coords_current_chain) >= 10 and asym_id not in polychains_coords:
+        polychains_coords[asym_id] = coords_current_chain
+    return polychains_coords
 
 
 def get_coords_from_file(local_cif_file):
@@ -68,14 +58,9 @@ def get_coords_from_file(local_cif_file):
     data_container = list_data_container[0]
 
     poly_ent_ids = get_poly_entities(data_container)
-    entity_to_asym = get_entity_to_asym_map(data_container)
 
-    chain_coords = {}
-    for ent_id in poly_ent_ids:
-        for asym_id in entity_to_asym[ent_id]:
-            cas = get_ca_coords(data_container, asym_id)
-            if len(cas) != 0:
-                chain_coords[asym_id] = cas
+    chain_coords = get_ca_coords(data_container, poly_ent_ids)
+
     return chain_coords
 
 
@@ -91,7 +76,7 @@ def get_coords_for_pdb_id(pdb_id, tmp_dir):
 
 def main():
 
-    chain_coords = get_coords_for_pdb_id("3hbx", "/tmp")
+    chain_coords = get_coords_for_pdb_id("2trx", "/tmp")
     print(chain_coords.keys())
 
 

--- a/scripts/coords_getter.py
+++ b/scripts/coords_getter.py
@@ -1,6 +1,7 @@
 import os
 import urllib.request
 from mmcif.io.IoAdapterCore import IoAdapterCore
+from Bio.Data.PDBData import protein_letters_3to1_extended
 
 
 aas = ["GLY", "ALA", "VAL", "LEU", "ILE", "PHE", "TYR", "TRP", "PRO", "HIS",
@@ -24,6 +25,8 @@ def get_ca_coords(data_container, poly_ent_ids: list):
     atom_sites = data_container.getObj('atom_site')
     coords_current_chain = []
     polychains_coords = {}
+    polychains_seqs = {}
+    current_seq = []
     asym_id = None
     for i in range(0, len(atom_sites.data)):
         d_row = atom_sites.getRowAttributeDict(i)
@@ -35,22 +38,28 @@ def get_ca_coords(data_container, poly_ent_ids: list):
             # we'll keep only chains with at least this residues. This should also filter out dna/rna
             if len(coords_current_chain) >= min_num_residues:
                 polychains_coords[asym_id] = coords_current_chain
+                polychains_seqs[asym_id] = "".join(current_seq)
             coords_current_chain = []
+            current_seq = []
         aa_type = d_row["label_comp_id"]
         atom_type = d_row["label_atom_id"]
         model_num = d_row["pdbx_PDB_model_num"]
         alt_loc = d_row["label_alt_id"]
         if atom_type == "CA" and model_num == "1" and aa_type in aas and (alt_loc == "." or alt_loc == "A"):
             coords_current_chain.append([float(d_row["Cartn_x"]), float(d_row["Cartn_y"]), float(d_row["Cartn_z"])])
+            current_seq.append(protein_letters_3to1_extended[aa_type])
         asym_id = current_asym_id
     if len(coords_current_chain) >= min_num_residues and asym_id not in polychains_coords:
         polychains_coords[asym_id] = coords_current_chain
-    return polychains_coords
+        polychains_seqs[asym_id] = "".join(current_seq)
+    return polychains_coords, polychains_seqs
 
 
 def get_coords_from_file(local_cif_file):
     """
-    Get a dictionary with keys asym_ids of protein polymer entities and values the coordinates as a list of 3-size lists.
+    Get 2 dictionaries: 1) coordinates, with keys asym_ids of protein polymer entities and values the
+    coordinates as a list of 3-size lists; 2) sequences, with keys asym_ids of protein polymer entities and values the
+    sequences (modelled residues and only standard aas)
     If no protein polymer entities found the dictionary will be empty.
     :param local_cif_file:
     :return:
@@ -60,9 +69,9 @@ def get_coords_from_file(local_cif_file):
     data_container = list_data_container[0]
 
     poly_ent_ids = get_poly_entities(data_container)
-    chain_coords = get_ca_coords(data_container, poly_ent_ids)
+    chain_coords, chain_seqs = get_ca_coords(data_container, poly_ent_ids)
 
-    return chain_coords
+    return chain_coords, chain_seqs
 
 
 def get_coords_for_pdb_id(pdb_id, tmp_dir):
@@ -70,10 +79,10 @@ def get_coords_for_pdb_id(pdb_id, tmp_dir):
     filepath_local = os.path.join(tmp_dir, "%s.cif.gz" % pdb_id)
     print("Downloading %s to %s" % (url, filepath_local))
     urllib.request.urlretrieve(url, filepath_local)
-    chain_coords = get_coords_from_file(filepath_local)
+    chain_coords, chain_seqs = get_coords_from_file(filepath_local)
     print("Found %d valid protein chains in %s. Asym_ids are : %s" % (len(chain_coords), pdb_id, ",".join(chain_coords.keys())))
     os.remove(filepath_local)
-    return chain_coords
+    return chain_coords, chain_seqs
 
 
 def main():

--- a/scripts/rcsb_dataset.py
+++ b/scripts/rcsb_dataset.py
@@ -5,7 +5,7 @@ import torch
 import esm
 import torch_geometric.nn as gnn
 from torch_geometric.data import Data, Dataset
-from Bio.PDB import PDBList, FastMMCIFParser, PDBParser
+from Bio.PDB import PDBParser
 from Bio.PDB.Polypeptide import is_aa
 from Bio.Data.PDBData import protein_letters_3to1_extended
 from coords_getter import get_coords_for_pdb_id

--- a/scripts/rcsb_dataset.py
+++ b/scripts/rcsb_dataset.py
@@ -6,9 +6,9 @@ import esm
 import torch_geometric.nn as gnn
 from torch_geometric.data import Data, Dataset
 from Bio.PDB import PDBList, FastMMCIFParser, PDBParser
-
 from Bio.PDB.Polypeptide import is_aa
 from Bio.Data.PDBData import protein_letters_3to1_extended
+from coords_getter import get_coords_for_pdb_id
 
 
 class RcsbDataset(Dataset):
@@ -76,15 +76,11 @@ class RcsbDataset(Dataset):
                 print(f"Embedding {row[0]}.{row[1]} is ready")
 
     def get_graph_from_entry_id(self, pdb):
-        pdb_provider = PDBList()
-        pdb_provider.retrieve_pdb_file(
-            pdb,
-            pdir="/tmp",
-            file_format="mmCif"
-        )
-        parser = FastMMCIFParser()
-        structure = parser.get_structure(f"{pdb}-structure", f"/tmp/{pdb}.cif")
-        return self.get_graph_from_structure(structure)
+        cas = get_coords_for_pdb_id(pdb, "/tmp")
+        graphs = []
+        for ch in cas.keys():
+            graphs.append((ch, self.get_chain_graph(cas[ch])))
+        return graphs
 
     def get_graph_from_pdb_file(self, pdb_file):
         parser = PDBParser()
@@ -93,12 +89,15 @@ class RcsbDataset(Dataset):
 
     def get_graph_from_structure(self, structure):
         chains = [s.id for s in structure.get_chains()]
-        return [(ch, self.get_chain_graph(structure, ch)) for ch in chains]
+        graphs = []
+        for ch in chains:
+            ca = [atom.get_coord() for atom in structure.get_atoms() if
+                  atom.get_name() == "CA" and is_aa(atom.parent.resname) and atom.parent.parent.id == ch]
+            graphs.append((ch, self.get_chain_graph(ca)))
+        return graphs
 
-    def get_chain_graph(self, structure, ch):
-        ca = [atom for atom in structure.get_atoms() if
-              atom.get_name() == "CA" and is_aa(atom.parent.resname) and atom.parent.parent.id == ch]
-        structure = torch.from_numpy(np.asarray([c.get_coord() for c in ca]))
+    def get_chain_graph(self, ca: list):
+        structure = torch.from_numpy(np.asarray(ca))
         edge_index = gnn.radius_graph(
             structure, r=self.eps, loop=False, num_workers=self.num_workers
         )

--- a/scripts/rcsb_dataset.py
+++ b/scripts/rcsb_dataset.py
@@ -74,7 +74,7 @@ class RcsbDataset(Dataset):
                 print(f"Embedding {row[0]}.{row[1]} is ready")
 
     def get_graph_from_entry_id(self, pdb):
-        cas, seqs = get_coords_for_pdb_id(pdb, "/tmp")
+        cas, seqs = get_coords_for_pdb_id(pdb)
         graphs = []
         for ch in cas.keys():
             graphs.append((ch, self.get_chain_graph(cas[ch], seqs[ch])))


### PR DESCRIPTION
Gains are:
- Getting bcif.gz instead of .cif.gz (smaller downloads and faster parsing)
- Directly parsing the http stream, avoiding IO for writing and deleting the cif files

The other difference is: only chains with at least 10 CA are kept. This should remove DNA/RNA and some other unwanted trash.